### PR TITLE
Lint the temp file not the actual file

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ class vcom(Linter):
     #   "SublimeLinter.linters.vcom.working_dir": "d:/tmp/tst/vhdl",
     # },
     #
-    cmd = ('vcom', '${args}', '${file}')
+    cmd = ('vcom', '${args}', '${temp_file}')
     multiline = False
     error_stream = util.STREAM_BOTH
     tempfile_suffix = 'vhd'
@@ -90,7 +90,7 @@ class SublimeLinterVcomRunTests(sublime_plugin.WindowCommand):
 ###############################################################################
 class vlog(Linter):
     # refer to description in vcom
-    cmd = ('vlog', '${args}', '${file}')
+    cmd = ('vlog', '${args}', '${temp_file}')
     multiline = False
     error_stream = util.STREAM_BOTH
     tempfile_suffix = 'v'


### PR DESCRIPTION
We use the special var `${temp_file}` which holds the name of the current temporary
file. (In contrast, `${file}` is a standard Sublime environment variable which always
points to the name of the buffer.)

You have to check this, if you set `lint_mode='background'` it will re-lint after edits. So if you fix a file and not save, the errors should still disappear, they should reflect the state of the buffer.

*I think* before this change, the errors were persistent until after save.

(E.g. easy to spot if you open the error panel `ctrl+k, a`.)

