### PR TITLE
Just use python 3.6 for flake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.3"
+  - "3.6"
 install:
   - pip install flake8
 script:


### PR DESCRIPTION
Python 3.3 is EOL and difficult to setup in containers

Although *you* actually haven't travis on (right now). It runs automated for basically all PR's *I* do. Maybe others also have automated setups.